### PR TITLE
Swift 2.3 - Using Generics and NSOperation

### DIFF
--- a/JustPromiseSwift/Info.plist
+++ b/JustPromiseSwift/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/JustPromiseSwift/JustPromiseSwift.h
+++ b/JustPromiseSwift/JustPromiseSwift.h
@@ -1,0 +1,19 @@
+//
+//  JustPromiseSwift.h
+//  JustPromiseSwift
+//
+//  Created by Keith Moon on 09/09/2016.
+//  Copyright © 2016 JUST EAT. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for JustPromiseSwift.
+FOUNDATION_EXPORT double JustPromiseSwiftVersionNumber;
+
+//! Project version string for JustPromiseSwift.
+FOUNDATION_EXPORT const unsigned char JustPromiseSwiftVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <JustPromiseSwift/PublicHeader.h>
+
+

--- a/JustPromiseSwift/Sources/AsyncOperation.swift
+++ b/JustPromiseSwift/Sources/AsyncOperation.swift
@@ -1,0 +1,176 @@
+//
+//  AsyncOperation.swift
+//  JUSTEAT
+//
+//  Created by Keith Moon on 29/08/2016.
+//  Copyright © 2016 JUST EAT. All rights reserved.
+//
+
+import Foundation
+
+/**
+ *  AsyncOperation
+ *
+ *  - abstract   Operation subclass to assist with running asynchronously.
+ *  - discussion A abstract subclass of NSOperation that handles the KVO reporting involved in implementing an asynchronous operation.
+ *               In abject conforming to OperationObserver can be provided, which will get called as the operation transition through it's execution lifecycle events.
+ *               AsyncOperation should be subclassed, not used directly. Subclasses should override start() without calling super.
+ *               Subclasses are reasonable for calling didStart() and didFinish() as appropriate, to ensure state is updated and observers are informed.
+ */
+public class AsyncOperation: NSOperation {
+    
+    // MARK: - State Reporting
+    
+    enum KeyPath: String {
+        case isExecuting = "isExecuting"
+        case isFinished = "isFinished"
+        case isCancelled = "isCancelled"
+    }
+    
+    private enum ExecutionState {
+        case Initial, Executing, Cancelled, Finished
+    }
+    
+    private var _executionState: ExecutionState = .Initial
+    
+    private var executionState: ExecutionState {
+        get {
+            var state: ExecutionState = .Initial
+            objc_sync_enter(self)
+            state = self._executionState
+            objc_sync_exit(self)
+            return state
+        }
+        set(newState) {
+            
+            let oldState = executionState
+            guard canTransitionFromState(from: oldState, toState: newState) else {
+                return
+            }
+            objc_sync_enter(self)
+            triggerWillKVOFromState(from: oldState, toState: newState)
+            self.transitionFromState(from: oldState, toState: newState)
+            triggerDidKVOFromState(from: oldState, toState: newState)
+            objc_sync_exit(self)
+        }
+    }
+    
+    private func triggerWillKVOFromState(from oldState: ExecutionState, toState newState: ExecutionState) {
+        
+        switch newState {
+        case .Executing:
+            willChangeValueForKey(KeyPath.isExecuting.rawValue)
+        case .Cancelled:
+            if oldState == .Executing {
+                willChangeValueForKey(KeyPath.isExecuting.rawValue)
+            }
+            willChangeValueForKey(KeyPath.isCancelled.rawValue)
+            willChangeValueForKey(KeyPath.isFinished.rawValue)
+        case .Finished:
+            if oldState == .Executing {
+                willChangeValueForKey(KeyPath.isExecuting.rawValue)
+            }
+            willChangeValueForKey(KeyPath.isFinished.rawValue)
+        case .Initial:
+            return
+        }
+    }
+    
+    private func triggerDidKVOFromState(from oldState: ExecutionState, toState newState: ExecutionState) {
+        
+        switch newState {
+        case .Executing:
+            didChangeValueForKey(KeyPath.isExecuting.rawValue)
+        case .Cancelled:
+            if oldState == .Executing {
+                didChangeValueForKey(KeyPath.isExecuting.rawValue)
+            }
+            didChangeValueForKey(KeyPath.isCancelled.rawValue)
+            didChangeValueForKey(KeyPath.isFinished.rawValue)
+        case .Finished:
+            if oldState == .Executing {
+                didChangeValueForKey(KeyPath.isExecuting.rawValue)
+            }
+            didChangeValueForKey(KeyPath.isFinished.rawValue)
+        case .Initial:
+            return
+        }
+        
+    }
+    
+    private func canTransitionFromState(from oldState: ExecutionState, toState newState: ExecutionState) -> Bool {
+        
+        switch (oldState, newState) {
+            
+        case (let oldState, let newState) where oldState == newState:
+            return false
+            
+        case (_, .Initial),
+             (.Finished, _),
+             (.Cancelled, _):
+            return false
+            
+        default:
+            return true
+        }
+    }
+    
+    private func transitionFromState(from oldState: ExecutionState, toState newState: ExecutionState) {
+        
+        switch newState {
+        case .Executing:
+            self._executionState = .Executing
+        case .Cancelled:
+            self._executionState = .Cancelled
+        case .Finished:
+            self._executionState = .Finished
+        case .Initial:
+            return
+        }
+    }
+    
+    override public var asynchronous: Bool {
+        return true
+    }
+    
+    override public var executing: Bool {
+        return self.executionState == .Executing
+    }
+    
+    override public var finished: Bool {
+        return self.executionState == .Cancelled || self.executionState == .Finished
+    }
+    
+    override public var cancelled: Bool {
+        return self.executionState == .Cancelled
+    }
+    
+    // MARK: - Execution
+    
+    override public func start() {
+        guard !cancelled && !finished else {
+            return
+        }
+        self.executionState = .Executing
+        execute()
+    }
+    
+    /**
+     Subclasses should override execute() and begin it's asynchronous work within it's implementation. Subclasses should not implement start(), as it's implementation in AsyncOperations handles state transition.
+     */
+    public func execute() {
+        fatalError("Should be overriden by subclass")
+    }
+    
+    // MARK: - Finishing
+    
+    public func finish() {
+        self.executionState = .Finished
+    }
+    
+    // MARK: - Cancellation
+    
+    override public func cancel() {
+        self.executionState = .Cancelled
+    }
+}

--- a/JustPromiseSwift/Sources/Promise.swift
+++ b/JustPromiseSwift/Sources/Promise.swift
@@ -1,0 +1,259 @@
+//
+//  Promise.swift
+//  JustPromises
+//
+//  Created by Keith Moon on 09/09/2016.
+//  Copyright © 2016 JUST EAT. All rights reserved.
+//
+
+import Foundation
+
+
+/// The state of the Promise
+///
+/// - Unresolved: The promise has let to be resolved
+/// - Result:     There is a result, associated value is the result
+/// - Error:      There is an erroe, associated value is the error
+/// - Cancelled:  The promise was cancelled
+public enum FutureState<FutureType> {
+    case Unresolved
+    case Result(FutureType)
+    case Error(ErrorType)
+    case Cancelled
+}
+
+public let sharedPromiseQueue = NSOperationQueue()
+
+
+/// A promise to fulfill try and fulfill a future value.
+/// Built onto of Operations, so can be combined with other operations,
+/// added to queues and used as a dependancy.
+public class Promise<FutureType>: AsyncOperation {
+    
+    private var executionBlock: (Promise<FutureType>) -> Void
+    
+    /// The state of the promise that will potentially contain the fulfilled future
+    public var futureState: FutureState<FutureType> = .Unresolved {
+        didSet {
+            switch futureState {
+            case .Error(_), .Result(_): finish()
+            default: break
+            }
+        }
+    }
+    
+    /// Create a promise with an execution block.
+    ///
+    /// - parameter executionBlock: Execution block that will fulfill the futureState of the Promise. Ensure that you update the futureState as part of this execution.
+    ///
+    /// - returns: A Promise, that has not been put on a queue. Call await() or awaitOnMainQueue() to enqueue
+    public init(executionBlock: (Promise<FutureType>) -> Void) {
+        self.executionBlock = executionBlock
+        super.init()
+    }
+    
+    /// Should not be called directly. This will fire the execution block.
+    override public func execute() {
+        executionBlock(self)
+    }
+    
+    /// Will cancel the promise
+    public override func cancel() {
+        super.cancel()
+        futureState = .Cancelled
+    }
+}
+
+extension Promise {
+    
+    
+    /// The promise will be added to the given queue.
+    ///
+    /// - parameter queue: The queue to await the promise on.
+    ///
+    /// - returns: The same promise will be returned, allowing chaining.
+    public func await(onQueue queue: NSOperationQueue = sharedPromiseQueue) -> Promise<FutureType> {
+        queue.addOperation(self)
+        return self
+    }
+    
+    
+    /// The promise will be added to the main queue.
+    ///
+    /// - returns: The same promise will be returned, allowing chaining.
+    public func awaitOnMainQueue() -> Promise<FutureType>  {
+        return await(onQueue: .mainQueue())
+    }
+}
+
+extension Promise {
+    
+    
+    /// Continue after this Promise with another Promise
+    ///
+    /// - parameter queue:          The queue to continue on
+    /// - parameter executionBlock: The block to create and return the next Promise
+    ///
+    /// - returns: The next created Promise, allows chaining.
+    public func continuation<NextFutureType>(onQueue queue: NSOperationQueue = sharedPromiseQueue, withBlock executionBlock: (Promise<FutureType>) -> Promise<NextFutureType>) -> Promise<NextFutureType> {
+        
+        let nextPromise = executionBlock(self)
+        nextPromise.addDependency(self)
+        queue.addOperation(nextPromise)
+        return nextPromise
+    }
+    
+    /// Continue after this Promise with a given block
+    ///
+    /// - parameter queue:          The queue to continue on
+    /// - parameter executionBlock: The block to execute after this Promise
+    public func continuation(onQueue queue: NSOperationQueue = sharedPromiseQueue, withBlock executionBlock: (Promise<FutureType>) -> Void) {
+        
+        let operaton = NSBlockOperation { [weak self] in
+            guard let strongSelf = self else { return }
+            executionBlock(strongSelf)
+        }
+        operaton.addDependency(self)
+        queue.addOperation(operaton)
+    }
+    
+    /// Continue after this Promise with another Promise on the main queue
+    ///
+    /// - parameter executionBlock: The block to create and return the next Promise
+    ///
+    /// - returns: The next created Promise, allows chaining.
+    public func continuationOnMainQueue<NextFutureType>(withBlock executionBlock: (Promise<FutureType>) -> Promise<NextFutureType>) -> Promise<NextFutureType> {
+        return continuation(onQueue: .mainQueue(), withBlock: executionBlock)
+    }
+    
+    /// Continue after this Promise a given block on the main queue
+    ///
+    /// - parameter executionBlock: The block to execute after this Promise
+    public func continuationOnMainQueue(withBlock executionBlock: (Promise<FutureType>) -> Void) {
+        continuation(onQueue: .mainQueue(), withBlock: executionBlock)
+    }
+    
+    
+    /// Continue after this Promise if it succeeds with another Promise
+    ///
+    /// - parameter queue:          The queue to continue on
+    /// - parameter executionBlock: The block to create and return the next Promise
+    ///
+    /// - returns: The next created Promise, allows chaining
+    public func continuationOnSuccess<NextFutureType>(onQueue queue: NSOperationQueue = sharedPromiseQueue, withBlock executionBlock: (Promise<FutureType>) -> Promise<NextFutureType>) -> Promise<NextFutureType> {
+        
+        let nextPromise = executionBlock(self)
+        
+        let existingBlock = nextPromise.executionBlock
+        
+        nextPromise.executionBlock = { [weak self] promise in
+            
+            guard let strongSelf = self else { return }
+            
+            // If we have a result, execute the block, otherwise inherit the previous promise's state
+            switch strongSelf.futureState {
+            
+            case .Result(_):
+                existingBlock(promise)
+                
+            case .Cancelled:
+                promise.futureState = .Cancelled
+                
+            case .Unresolved:
+                promise.futureState = .Unresolved
+                
+            case .Error(let error):
+                promise.futureState = .Error(error)
+            }
+        }
+        nextPromise.addDependency(self)
+        queue.addOperation(nextPromise)
+        return nextPromise
+    }
+    
+    /// Continue after this Promise if it succeeds, with a given block on the given queue
+    ///
+    /// - parameter queue:          The queue to continue on
+    /// - parameter executionBlock: The block to execute after this Promise
+    public func continuationOnSuccess(onQueue queue: NSOperationQueue = sharedPromiseQueue, withBlock executionBlock: (Promise<FutureType>) -> Void) {
+        
+        let operaton = NSBlockOperation { [weak self] in
+            
+            guard let strongSelf = self else { return }
+            
+            // If we have a result, execute the block, otherwise inherit the previous promise's state
+            switch strongSelf.futureState {
+            case .Result(_): executionBlock(strongSelf)
+            default: break
+            }
+        }
+        operaton.addDependency(self)
+        queue.addOperation(operaton)
+    }
+    
+    /// Continue after this Promise if it succeeds with another Promise
+    ///
+    /// - parameter executionBlock: The block to create and return the next Promise
+    ///
+    /// - returns: The next created Promise, allows chaining
+    public func continuationOnSuccessOnMainQueue<NextFutureType>(withBlock executionBlock: (Promise<FutureType>) -> Promise<NextFutureType>) -> Promise<NextFutureType> {
+        return continuationOnSuccess(onQueue: .mainQueue(), withBlock: executionBlock)
+    }
+    
+    /// Continue after this Promise if it succeeds, with a given block on the main queue
+    ///
+    /// - parameter executionBlock: The block to execute after this Promise
+    public func continuationOnSuccessOnMainQueue(withBlock executionBlock: (Promise<FutureType>) -> Void) {
+        continuationOnSuccess(onQueue: .mainQueue(), withBlock: executionBlock)
+    }
+}
+
+extension Array where Element: NSOperation {
+    
+    
+    /// Continue after all these operations are finished with a Promise
+    ///
+    /// - parameter queue:          The queue to continue on
+    /// - parameter executionBlock: The block to create and return the next Promise
+    ///
+    /// - returns: The next created Promise, allows chaining
+    public func continuation<NextFutureType>(onQueue queue: NSOperationQueue = sharedPromiseQueue, withBlock executionBlock: () -> Promise<NextFutureType>) -> Promise<NextFutureType> {
+        
+        let nextPromise = executionBlock()
+        for operation in self {
+            nextPromise.addDependency(operation)
+        }
+        queue.addOperation(nextPromise)
+        
+        return nextPromise
+    }
+    
+    /// Continue after all these operations are finished with a Promise
+    ///
+    /// - parameter queue:          The queue to continue on
+    /// - parameter executionBlock: The block to execute after all operations are finished
+    public func continuation(onQueue queue: NSOperationQueue = sharedPromiseQueue, withBlock executionBlock: () -> Void) {
+        
+        let operaton = NSBlockOperation(block: executionBlock)
+        for operation in self {
+            operation.addDependency(operation)
+        }
+        queue.addOperation(operaton)
+    }
+    
+    /// Continue after all these operations are finished with a Promise on given queue
+    ///
+    /// - parameter executionBlock: The block to create and return the next Promise
+    ///
+    /// - returns: The next created Promise, allows chaining
+    public func continuationOnMainQueue<NextFutureType>(withBlock executionBlock: () -> Promise<NextFutureType>) -> Promise<NextFutureType> {
+        return continuation(onQueue: .mainQueue(), withBlock: executionBlock)
+    }
+    
+    /// Continue after all these operations are finished with a Promise on main queue
+    ///
+    /// - parameter executionBlock: The block to execute after all operations are finished
+    public func continuationOnMainQueue(withBlock executionBlock: () -> Void) {
+        continuation(onQueue: .mainQueue(), withBlock: executionBlock)
+    }
+}

--- a/JustPromiseSwiftTests/Info.plist
+++ b/JustPromiseSwiftTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/JustPromiseSwiftTests/PromiseTests.swift
+++ b/JustPromiseSwiftTests/PromiseTests.swift
@@ -1,0 +1,249 @@
+//
+//  PromiseTests.swift
+//  JustPromises
+//
+//  Created by Keith Moon on 12/09/2016.
+//  Copyright © 2016 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import Foundation
+import JustPromiseSwift
+
+class PromiseTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testPromiseWillExecuteWhenAwaiting() {
+        
+        let asyncExpectation = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            promise.futureState = .Result()
+            asyncExpectation.fulfill()
+        }.await()
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseWillExecuteOnMainQueueWhenAwaiting() {
+        
+        let asyncExpectation = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            let onMainQueue = NSThread.currentThread().isMainThread
+            XCTAssertTrue(onMainQueue)
+            
+            promise.futureState = .Result()
+            asyncExpectation.fulfill()
+        }.awaitOnMainQueue()
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseCanBeContinued() {
+        
+        let asyncExpectation1 = expectationWithDescription("Await execution")
+        let asyncExpectation2 = expectationWithDescription("Await execution")
+        let asyncExpectation3 = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            promise.futureState = .Result()
+            asyncExpectation1.fulfill()
+            
+            }.await().continuation { previousPromise in
+                
+                return Promise<Void> { promise in
+                    promise.futureState = .Result()
+                    asyncExpectation2.fulfill()
+                }
+                
+            }.continuation { _ in
+                
+                asyncExpectation3.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseCanBeContinuedOnMainQueue() {
+        
+        let asyncExpectation1 = expectationWithDescription("Await execution")
+        let asyncExpectation2 = expectationWithDescription("Await execution")
+        let asyncExpectation3 = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            promise.futureState = .Result()
+            asyncExpectation1.fulfill()
+            
+            }.await().continuationOnMainQueue { previousPromise in
+                
+                return Promise<Void> { promise in
+                    
+                    let onMainQueue = NSThread.currentThread().isMainThread
+                    XCTAssertTrue(onMainQueue)
+                    
+                    promise.futureState = .Result()
+                    asyncExpectation2.fulfill()
+                }
+                
+            }.continuationOnMainQueue { _ in
+                
+                let onMainQueue = NSThread.currentThread().isMainThread
+                XCTAssertTrue(onMainQueue)
+                
+                asyncExpectation3.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseCanBeContinuedOnSuccess() {
+        
+        let asyncExpectation1 = expectationWithDescription("Await execution")
+        let asyncExpectation2 = expectationWithDescription("Await execution")
+        let asyncExpectation3 = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            promise.futureState = .Result()
+            asyncExpectation1.fulfill()
+            
+            }.await().continuationOnSuccess { previousPromise in
+                
+                return Promise<Void> { promise in
+                    
+                    promise.futureState = .Result()
+                    asyncExpectation2.fulfill()
+                }
+                
+            }.continuationOnSuccess { _ in
+                
+                asyncExpectation3.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseContinuedOnSuccessDoesntExecuteIfFailed() {
+        
+        enum TestError: ErrorType {
+            case SomethingWentWrong
+        }
+        
+        let asyncExpectation1 = expectationWithDescription("Await execution")
+        let asyncExpectation2 = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            promise.futureState = .Error(TestError.SomethingWentWrong)
+            asyncExpectation1.fulfill()
+            
+            }.await().continuationOnSuccess { previousPromise in
+                
+                return Promise<Void> { promise in
+                    
+                    promise.futureState = .Result()
+                    XCTFail()
+                }
+                
+            }.continuation { _ in
+                
+                asyncExpectation2.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseFinalContinuedOnSuccessDoesntExecuteIfFailed() {
+        
+        enum TestError: ErrorType {
+            case SomethingWentWrong
+        }
+        
+        let asyncExpectation1 = expectationWithDescription("Await execution")
+        let asyncExpectation2 = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            promise.futureState = .Result()
+            asyncExpectation1.fulfill()
+            
+            }.await().continuationOnSuccess { previousPromise in
+                
+                return Promise<Void> { promise in
+                    
+                    let error = TestError.SomethingWentWrong
+                    promise.futureState = .Error(error)
+                    asyncExpectation2.fulfill()
+                }
+                
+            }.continuationOnSuccess { promise in
+                
+                XCTFail()
+        }
+        
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPromiseCanBeContinuedOnSuccessOnMainQueue() {
+        
+        let asyncExpectation1 = expectationWithDescription("Await execution")
+        let asyncExpectation2 = expectationWithDescription("Await execution")
+        let asyncExpectation3 = expectationWithDescription("Await execution")
+        
+        let _ = Promise<Void> { promise in
+            
+            promise.futureState = .Result()
+            asyncExpectation1.fulfill()
+            
+            }.await().continuationOnSuccessOnMainQueue { previousPromise in
+                
+                return Promise<Void> { promise in
+                    
+                    let onMainQueue = NSThread.currentThread().isMainThread
+                    XCTAssertTrue(onMainQueue)
+                    
+                    promise.futureState = .Result()
+                    asyncExpectation2.fulfill()
+                }
+                
+            }.continuationOnSuccessOnMainQueue { _ in
+                
+                let onMainQueue = NSThread.currentThread().isMainThread
+                XCTAssertTrue(onMainQueue)
+                
+                asyncExpectation3.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/JustPromises.podspec
+++ b/JustPromises.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "JustPromises"
-  s.version      = "2.0.0"
+  s.version      = "3.0.0"
   s.summary      = "A lightweight and thread-safe implementation of Promises & Futures in Objective-C for iOS and OS X."
 
   s.description  = <<-DESC
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
   # s.platform     = :ios, "5.0"
 
   #  When using multiple platforms
-  s.ios.deployment_target = "5.0"
+  s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.7"
 
 
@@ -77,7 +77,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/justeat/JustPromises.git", :tag => "2.0.0" }
+  s.source       = { :git => "https://github.com/justeat/JustPromises.git", :tag => "3.0.0" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -88,10 +88,20 @@ Pod::Spec.new do |s|
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = "JustPromises", "JustPromises/**/*.{h,m}"
+  s.source_files  = "JustPromises", "JustPromises/**/*.{h,m}", "JustPromiseSwift/**/*.{h,m,swift}"
   s.exclude_files = "JustPromises/Exclude"
 
   # s.public_header_files = "JustPromises/**/*.h"
+
+  # --- SubSpec -----------
+
+  s.subspec "Objective-C" do |sub|
+    sub.source_files = "JustPromises/**/*.{h,m}"
+  end
+
+  s.subspec "Swift" do |sub|
+    sub.source_files = "JustPromiseSwift/**/*.{h,m,swift}"
+  end
 
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/JustPromises.podspec
+++ b/JustPromises.podspec
@@ -97,12 +97,16 @@ Pod::Spec.new do |s|
 
   s.subspec "Objective-C" do |sub|
     sub.source_files = "JustPromises/**/*.{h,m}"
+    sub.pod_target_xcconfig = { 'SWIFT_VERSION' => '2.3' }
   end
 
   s.subspec "Swift" do |sub|
     sub.source_files = "JustPromiseSwift/**/*.{h,m,swift}"
+    sub.pod_target_xcconfig = { 'SWIFT_VERSION' => '2.3' }
   end
 
+  # ――― Swift Version ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '2.3' }
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #

--- a/JustPromises.xcodeproj/project.pbxproj
+++ b/JustPromises.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F393C4F1D82CEDE0045E6E7 /* JustPromiseSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F393C461D82CEDE0045E6E7 /* JustPromiseSwift.framework */; };
+		2F393C561D82CEDF0045E6E7 /* JustPromiseSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F393C481D82CEDE0045E6E7 /* JustPromiseSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F393C5F1D82D01C0045E6E7 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F393C5E1D82D01C0045E6E7 /* AsyncOperation.swift */; };
+		2F393C611D82D9FC0045E6E7 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F393C601D82D9FC0045E6E7 /* Promise.swift */; };
+		2F393C631D86BA620045E6E7 /* PromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F393C621D86BA620045E6E7 /* PromiseTests.swift */; };
 		4F74B0E91B47CF6500595442 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F74B0E31B47CF6500595442 /* AppDelegate.m */; };
 		4F74B0EA1B47CF6500595442 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4F74B0E41B47CF6500595442 /* LaunchScreen.xib */; };
 		4F74B0ED1B47CF6500595442 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F74B0E81B47CF6500595442 /* main.m */; };
@@ -26,6 +31,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2F393C501D82CEDE0045E6E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 72E1F6B51A275A0A00F2DB7F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2F393C451D82CEDE0045E6E7;
+			remoteInfo = JustPromiseSwift;
+		};
 		4FBCFFE91B46DC9F007BD426 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 72E1F6B51A275A0A00F2DB7F /* Project object */;
@@ -36,6 +48,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2F393C461D82CEDE0045E6E7 /* JustPromiseSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JustPromiseSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F393C481D82CEDE0045E6E7 /* JustPromiseSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JustPromiseSwift.h; sourceTree = "<group>"; };
+		2F393C491D82CEDE0045E6E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2F393C4E1D82CEDE0045E6E7 /* JustPromiseSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JustPromiseSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F393C551D82CEDE0045E6E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2F393C5E1D82D01C0045E6E7 /* AsyncOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
+		2F393C601D82D9FC0045E6E7 /* Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
+		2F393C621D86BA620045E6E7 /* PromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; };
 		4F35A55B1A6FBD15008B3A04 /* JustPromises.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = JustPromises.podspec; sourceTree = "<group>"; };
 		4F74B0AE1B47CD0300595442 /* JustPromisesDEMO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JustPromisesDEMO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F74B0E21B47CF6500595442 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -64,6 +84,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2F393C421D82CEDE0045E6E7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2F393C4B1D82CEDE0045E6E7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F393C4F1D82CEDE0045E6E7 /* JustPromiseSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4F74B0AB1B47CD0300595442 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -90,6 +125,34 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F393C471D82CEDE0045E6E7 /* JustPromiseSwift */ = {
+			isa = PBXGroup;
+			children = (
+				2F393C5D1D82D01C0045E6E7 /* Sources */,
+				2F393C481D82CEDE0045E6E7 /* JustPromiseSwift.h */,
+				2F393C491D82CEDE0045E6E7 /* Info.plist */,
+			);
+			path = JustPromiseSwift;
+			sourceTree = "<group>";
+		};
+		2F393C521D82CEDE0045E6E7 /* JustPromiseSwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				2F393C551D82CEDE0045E6E7 /* Info.plist */,
+				2F393C621D86BA620045E6E7 /* PromiseTests.swift */,
+			);
+			path = JustPromiseSwiftTests;
+			sourceTree = "<group>";
+		};
+		2F393C5D1D82D01C0045E6E7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				2F393C5E1D82D01C0045E6E7 /* AsyncOperation.swift */,
+				2F393C601D82D9FC0045E6E7 /* Promise.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		4F74B0E11B47CF6500595442 /* JustPromisesDEMO */ = {
 			isa = PBXGroup;
 			children = (
@@ -139,6 +202,8 @@
 				4FBCFFFC1B46DCE2007BD426 /* JustPromises */,
 				4FBC00091B46DD1B007BD426 /* JustPromisesTests */,
 				4F74B0E11B47CF6500595442 /* JustPromisesDEMO */,
+				2F393C471D82CEDE0045E6E7 /* JustPromiseSwift */,
+				2F393C521D82CEDE0045E6E7 /* JustPromiseSwiftTests */,
 				72E1F6BE1A275A0A00F2DB7F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -149,6 +214,8 @@
 				4FBCFFDE1B46DC9F007BD426 /* JustPromises.framework */,
 				4FBCFFE71B46DC9F007BD426 /* JustPromisesTests.xctest */,
 				4F74B0AE1B47CD0300595442 /* JustPromisesDEMO.app */,
+				2F393C461D82CEDE0045E6E7 /* JustPromiseSwift.framework */,
+				2F393C4E1D82CEDE0045E6E7 /* JustPromiseSwiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -156,6 +223,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		2F393C431D82CEDE0045E6E7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F393C561D82CEDF0045E6E7 /* JustPromiseSwift.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4FBCFFDB1B46DC9F007BD426 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -170,6 +245,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		2F393C451D82CEDE0045E6E7 /* JustPromiseSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2F393C5B1D82CEDF0045E6E7 /* Build configuration list for PBXNativeTarget "JustPromiseSwift" */;
+			buildPhases = (
+				2F393C411D82CEDE0045E6E7 /* Sources */,
+				2F393C421D82CEDE0045E6E7 /* Frameworks */,
+				2F393C431D82CEDE0045E6E7 /* Headers */,
+				2F393C441D82CEDE0045E6E7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = JustPromiseSwift;
+			productName = JustPromiseSwift;
+			productReference = 2F393C461D82CEDE0045E6E7 /* JustPromiseSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2F393C4D1D82CEDE0045E6E7 /* JustPromiseSwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2F393C5C1D82CEDF0045E6E7 /* Build configuration list for PBXNativeTarget "JustPromiseSwiftTests" */;
+			buildPhases = (
+				2F393C4A1D82CEDE0045E6E7 /* Sources */,
+				2F393C4B1D82CEDE0045E6E7 /* Frameworks */,
+				2F393C4C1D82CEDE0045E6E7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2F393C511D82CEDE0045E6E7 /* PBXTargetDependency */,
+			);
+			name = JustPromiseSwiftTests;
+			productName = JustPromiseSwiftTests;
+			productReference = 2F393C4E1D82CEDE0045E6E7 /* JustPromiseSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		4F74B0AD1B47CD0300595442 /* JustPromisesDEMO */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4F74B0D21B47CD0300595442 /* Build configuration list for PBXNativeTarget "JustPromisesDEMO" */;
@@ -229,9 +340,20 @@
 		72E1F6B51A275A0A00F2DB7F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastSwiftUpdateCheck = 0800;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "JUST EAT";
 				TargetAttributes = {
+					2F393C451D82CEDE0045E6E7 = {
+						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = YAXJZJ267E;
+						ProvisioningStyle = Automatic;
+					};
+					2F393C4D1D82CEDE0045E6E7 = {
+						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = YAXJZJ267E;
+						ProvisioningStyle = Automatic;
+					};
 					4F74B0AD1B47CD0300595442 = {
 						CreatedOnToolsVersion = 6.4;
 					};
@@ -260,11 +382,27 @@
 				4FBCFFDD1B46DC9F007BD426 /* JustPromises */,
 				4FBCFFE61B46DC9F007BD426 /* JustPromisesTests */,
 				4F74B0AD1B47CD0300595442 /* JustPromisesDEMO */,
+				2F393C451D82CEDE0045E6E7 /* JustPromiseSwift */,
+				2F393C4D1D82CEDE0045E6E7 /* JustPromiseSwiftTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2F393C441D82CEDE0045E6E7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2F393C4C1D82CEDE0045E6E7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4F74B0AC1B47CD0300595442 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -290,6 +428,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2F393C411D82CEDE0045E6E7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F393C5F1D82D01C0045E6E7 /* AsyncOperation.swift in Sources */,
+				2F393C611D82D9FC0045E6E7 /* Promise.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2F393C4A1D82CEDE0045E6E7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F393C631D86BA620045E6E7 /* PromiseTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4F74B0AA1B47CD0300595442 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -323,6 +478,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2F393C511D82CEDE0045E6E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2F393C451D82CEDE0045E6E7 /* JustPromiseSwift */;
+			targetProxy = 2F393C501D82CEDE0045E6E7 /* PBXContainerItemProxy */;
+		};
 		4FBCFFEA1B46DC9F007BD426 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4FBCFFDD1B46DC9F007BD426 /* JustPromises */;
@@ -342,6 +502,114 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		2F393C571D82CEDF0045E6E7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = YAXJZJ267E;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = JustPromiseSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.just-eat.JustPromiseSwift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2F393C581D82CEDF0045E6E7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = YAXJZJ267E;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = JustPromiseSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.just-eat.JustPromiseSwift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		2F393C591D82CEDF0045E6E7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = YAXJZJ267E;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = JustPromiseSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.just-eat.JustPromiseSwiftTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		2F393C5A1D82CEDF0045E6E7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = YAXJZJ267E;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = JustPromiseSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.just-eat.JustPromiseSwiftTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+			};
+			name = Release;
+		};
 		4F74B0CE1B47CD0300595442 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -380,7 +648,7 @@
 		4FBCFFF61B46DC9F007BD426 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -404,7 +672,7 @@
 		4FBCFFF71B46DC9F007BD426 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -468,9 +736,11 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -478,6 +748,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -494,6 +765,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -510,15 +782,18 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -528,6 +803,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -535,6 +812,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2F393C5B1D82CEDF0045E6E7 /* Build configuration list for PBXNativeTarget "JustPromiseSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2F393C571D82CEDF0045E6E7 /* Debug */,
+				2F393C581D82CEDF0045E6E7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2F393C5C1D82CEDF0045E6E7 /* Build configuration list for PBXNativeTarget "JustPromiseSwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2F393C591D82CEDF0045E6E7 /* Debug */,
+				2F393C5A1D82CEDF0045E6E7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4F74B0D21B47CD0300595442 /* Build configuration list for PBXNativeTarget "JustPromisesDEMO" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/JustPromises.xcodeproj/xcshareddata/xcschemes/JustPromises.xcscheme
+++ b/JustPromises.xcodeproj/xcshareddata/xcschemes/JustPromises.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,11 +37,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      buildConfiguration = "Debug">
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -67,11 +67,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -89,10 +89,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/JustPromises.xcodeproj/xcshareddata/xcschemes/JustPromisesDEMO.xcscheme
+++ b/JustPromises.xcodeproj/xcshareddata/xcschemes/JustPromisesDEMO.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -42,11 +42,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -65,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Ground up rebuild ofJustPromise in Swift 2.3 using `NSOperation`s as the base.

A `Promise` is a `NSOperation` with the future result state on top. Generics used to provide a future result of the right type, this is NOT Objective-C compatible.

The current code has 2 objects `JEPromise` and `JEFuture` but `JEPromise` did very little. So now the main object is `Promise`. All existing features supported except `JEProgress`, as I'm unsure what purpose it serves.
