### PR TITLE
Adding Retry Functionality

### DIFF
--- a/JustPromisesSwift/Sources/Promise.swift
+++ b/JustPromisesSwift/Sources/Promise.swift
@@ -66,7 +66,7 @@ open class Promise<FutureType>: AsyncOperation {
     
     // Number of times to retry if error. Promise will retry until result or retries runout, in which case the 
     // last error is returned.
-    public var retryCount: Int = 0
+    public var retryCount: UInt = 0
     
     /// Create a promise with an execution block.
     ///

--- a/JustPromisesSwift/Sources/Promise.swift
+++ b/JustPromisesSwift/Sources/Promise.swift
@@ -49,12 +49,24 @@ open class Promise<FutureType>: AsyncOperation {
     /// The state of the promise that will potentially contain the fulfilled future
     public var futureState: FutureState<FutureType> = .unresolved {
         didSet {
-            switch futureState {
-            case .error(_), .result(_): finish()
-            default: break
+            switch (futureState, retryCount) {
+                
+            case (.error(_), let retry) where retry > 0:
+                retryCount = retryCount - 1
+                execute()
+                
+            case (.error(_), _), (.result(_), _):
+                finish()
+                
+            default:
+                break
             }
         }
     }
+    
+    // Number of times to retry if error. Promise will retry until result or retries runout, in which case the 
+    // last error is returned.
+    public var retryCount: Int = 0
     
     /// Create a promise with an execution block.
     ///

--- a/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSTests.swift
+++ b/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import Foundation
 import JustPromisesSwift_iOS
+import Dispatch
 
 enum TestError: Error {
     case somethingWentWrong
@@ -257,13 +258,16 @@ class PromiseTests: XCTestCase {
         
         let promise = Promise<Bool>(executionBlock: { promise in
             
-            let didSucceed = fail4Times.tryToSucceed()
-            
-            if didSucceed {
-                promise.futureState = .result(true)
-            } else {
-                attempt = attempt + 1
-                promise.futureState = .error(Failed.attempt(attempt))
+            DispatchQueue.main.async {
+                
+                let didSucceed = fail4Times.tryToSucceed()
+                
+                if didSucceed {
+                    promise.futureState = .result(true)
+                } else {
+                    attempt = attempt + 1
+                    promise.futureState = .error(Failed.attempt(attempt))
+                }
             }
         })
         
@@ -292,13 +296,16 @@ class PromiseTests: XCTestCase {
         
         let promise = Promise<Bool>(executionBlock: { promise in
             
-            let didSucceed = fail6Times.tryToSucceed()
-            
-            if didSucceed {
-                promise.futureState = .result(true)
-            } else {
-                attempt = attempt + 1
-                promise.futureState = .error(Failed.attempt(attempt))
+            DispatchQueue.main.async {
+             
+                let didSucceed = fail6Times.tryToSucceed()
+                
+                if didSucceed {
+                    promise.futureState = .result(true)
+                } else {
+                    attempt = attempt + 1
+                    promise.futureState = .error(Failed.attempt(attempt))
+                }
             }
         })
         


### PR DESCRIPTION
As requested by @jregnauld I've added the ability to have Promises retry. 

```Promise``` now has a ```retryCount``` property, which defaults to ```0```. If the retry count is above zero and the Promise results in an error, the Promise will retry before finishing.

Tests added.