### PR TITLE
Fixing bug in array continuation + additional Unit Tests

### DIFF
--- a/JustPromises.podspec
+++ b/JustPromises.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "JustPromises"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.summary      = "A lightweight and thread-safe implementation of Promises & Futures in Objective-C for iOS and OS X."
 
   s.description  = <<-DESC
@@ -79,7 +79,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/justeat/JustPromises.git", :tag => "3.0.0" }
+  s.source       = { :git => "https://github.com/justeat/JustPromises.git", :tag => "3.0.1" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/JustPromises.xcodeproj/project.pbxproj
+++ b/JustPromises.xcodeproj/project.pbxproj
@@ -11,11 +11,11 @@
 		2F5829341DF4A5CF0033C3D4 /* JustPromisesSwift_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F58292B1DF4A5CF0033C3D4 /* JustPromisesSwift_tvOS.framework */; };
 		2F5829501DF4A6040033C3D4 /* JustPromisesSwift_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F5829471DF4A6040033C3D4 /* JustPromisesSwift_macOS.framework */; };
 		2F58297E1DF4A7F20033C3D4 /* JustPromisesSwift_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5829671DF4A7DE0033C3D4 /* JustPromisesSwift_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2F58297F1DF4A7F80033C3D4 /* JustPromisesSwift_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSTests.swift */; };
+		2F58297F1DF4A7F80033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift */; };
 		2F5829801DF4A8040033C3D4 /* JustPromisesSwift_macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F58296E1DF4A7DE0033C3D4 /* JustPromisesSwift_macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2F5829811DF4A80A0033C3D4 /* JustPromisesSwift_macOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSTests.swift */; };
+		2F5829811DF4A80A0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift */; };
 		2F5829821DF4A8110033C3D4 /* JustPromisesSwift_tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5829751DF4A7DE0033C3D4 /* JustPromisesSwift_tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2F5829831DF4A8150033C3D4 /* JustPromisesSwift_tvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSTests.swift */; };
+		2F5829831DF4A8150033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift */; };
 		2F5829841DF4A81D0033C3D4 /* JustPromisesSwift_watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F58297C1DF4A7DE0033C3D4 /* JustPromisesSwift_watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2F5829851DF4A8280033C3D4 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5829611DF4A7DE0033C3D4 /* AsyncOperation.swift */; };
 		2F5829861DF4A8280033C3D4 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5829621DF4A7DE0033C3D4 /* Promise.swift */; };
@@ -41,6 +41,9 @@
 		4FCF53A01B47F5480025D30D /* JEFuture+JEDotNotation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FCF539E1B47F5480025D30D /* JEFuture+JEDotNotation.h */; };
 		4FCF53A11B47F5480025D30D /* JEFuture+JEDotNotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF539F1B47F5480025D30D /* JEFuture+JEDotNotation.m */; };
 		4FCF53A31B47F5820025D30D /* JEFuture_DotNotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF53A21B47F5820025D30D /* JEFuture_DotNotationTests.m */; };
+		B1FA8F9D1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */; };
+		B1FA8F9F1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */; };
+		B1FA8FA11E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,15 +91,15 @@
 		2F5829661DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F5829671DF4A7DE0033C3D4 /* JustPromisesSwift_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JustPromisesSwift_iOS.h; sourceTree = "<group>"; };
 		2F5829691DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSTests.swift; sourceTree = "<group>"; };
+		2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSPromiseTests.swift; sourceTree = "<group>"; };
 		2F58296D1DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F58296E1DF4A7DE0033C3D4 /* JustPromisesSwift_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JustPromisesSwift_macOS.h; sourceTree = "<group>"; };
 		2F5829701DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_macOSTests.swift; sourceTree = "<group>"; };
+		2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_macOSPromiseTests.swift; sourceTree = "<group>"; };
 		2F5829741DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F5829751DF4A7DE0033C3D4 /* JustPromisesSwift_tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JustPromisesSwift_tvOS.h; sourceTree = "<group>"; };
 		2F5829771DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_tvOSTests.swift; sourceTree = "<group>"; };
+		2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_tvOSPromiseTests.swift; sourceTree = "<group>"; };
 		2F58297B1DF4A7DE0033C3D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F58297C1DF4A7DE0033C3D4 /* JustPromisesSwift_watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JustPromisesSwift_watchOS.h; sourceTree = "<group>"; };
 		4F35A55B1A6FBD15008B3A04 /* JustPromises.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = JustPromises.podspec; sourceTree = "<group>"; };
@@ -126,6 +129,9 @@
 		4FCF53A21B47F5820025D30D /* JEFuture_DotNotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JEFuture_DotNotationTests.m; sourceTree = "<group>"; };
 		B13CA05B1DD0D81900E4F710 /* README_ObjC.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_ObjC.md; sourceTree = "<group>"; };
 		B13CA05C1DD0D82C00E4F710 /* README_Swift.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_Swift.md; sourceTree = "<group>"; };
+		B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSArrayTests.swift; sourceTree = "<group>"; };
+		B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_macOSArrayTests.swift; sourceTree = "<group>"; };
+		B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_tvOSArrayTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -259,7 +265,8 @@
 			isa = PBXGroup;
 			children = (
 				2F5829691DF4A7DE0033C3D4 /* Info.plist */,
-				2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSTests.swift */,
+				2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift */,
+				B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -286,7 +293,8 @@
 			isa = PBXGroup;
 			children = (
 				2F5829701DF4A7DE0033C3D4 /* Info.plist */,
-				2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSTests.swift */,
+				2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift */,
+				B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -313,7 +321,8 @@
 			isa = PBXGroup;
 			children = (
 				2F5829771DF4A7DE0033C3D4 /* Info.plist */,
-				2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSTests.swift */,
+				2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift */,
+				B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -810,7 +819,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F58297F1DF4A7F80033C3D4 /* JustPromisesSwift_iOSTests.swift in Sources */,
+				2F58297F1DF4A7F80033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift in Sources */,
+				B1FA8F9D1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -836,7 +846,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F5829831DF4A8150033C3D4 /* JustPromisesSwift_tvOSTests.swift in Sources */,
+				2F5829831DF4A8150033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift in Sources */,
+				B1FA8FA11E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -853,7 +864,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F5829811DF4A80A0033C3D4 /* JustPromisesSwift_macOSTests.swift in Sources */,
+				2F5829811DF4A80A0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift in Sources */,
+				B1FA8F9F1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1496,6 +1508,7 @@
 				2F5829151DF4A54C0033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		2F5829161DF4A54C0033C3D4 /* Build configuration list for PBXNativeTarget "JustPromisesSwift_iOSTests" */ = {
 			isa = XCConfigurationList;
@@ -1504,6 +1517,7 @@
 				2F5829181DF4A54C0033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		2F5829231DF4A58D0033C3D4 /* Build configuration list for PBXNativeTarget "JustPromisesSwift_watchOS" */ = {
 			isa = XCConfigurationList;
@@ -1512,6 +1526,7 @@
 				2F5829251DF4A58D0033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		2F58293C1DF4A5CF0033C3D4 /* Build configuration list for PBXNativeTarget "JustPromisesSwift_tvOS" */ = {
 			isa = XCConfigurationList;
@@ -1520,6 +1535,7 @@
 				2F58293E1DF4A5CF0033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		2F58293F1DF4A5CF0033C3D4 /* Build configuration list for PBXNativeTarget "JustPromisesSwift_tvOSTests" */ = {
 			isa = XCConfigurationList;
@@ -1528,6 +1544,7 @@
 				2F5829411DF4A5CF0033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		2F5829581DF4A6040033C3D4 /* Build configuration list for PBXNativeTarget "JustPromisesSwift_macOS" */ = {
 			isa = XCConfigurationList;
@@ -1536,6 +1553,7 @@
 				2F58295A1DF4A6040033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		2F58295B1DF4A6040033C3D4 /* Build configuration list for PBXNativeTarget "JustPromisesSwift_macOSTests" */ = {
 			isa = XCConfigurationList;
@@ -1544,6 +1562,7 @@
 				2F58295D1DF4A6040033C3D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4F74B0D21B47CD0300595442 /* Build configuration list for PBXNativeTarget "JustPromisesDEMO" */ = {
 			isa = XCConfigurationList;

--- a/JustPromisesSwift/Sources/Promise.swift
+++ b/JustPromisesSwift/Sources/Promise.swift
@@ -249,7 +249,7 @@ extension Array where Element: Operation {
         
         let blockOperation = BlockOperation(block: executionBlock)
         for operation in self {
-            operation.addDependency(operation)
+            blockOperation.addDependency(operation)
         }
         queue.addOperation(blockOperation)
     }

--- a/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSArrayTests.swift
+++ b/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSArrayTests.swift
@@ -1,0 +1,113 @@
+//
+//  JustPromisesSwift_iOSArrayTests.swift
+//  JustPromisesSwift_iOSTests
+//
+//  Created by Keith Moon [Contractor] on 2/10/17.
+//  Copyright © 2017 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import JustPromisesSwift_iOS
+import Dispatch
+import Foundation
+
+class DelayedOperation: AsyncOperation {
+    
+    var complete: Bool = false
+    let queue = DispatchQueue(label: UUID().uuidString)
+    
+    override func execute() {
+        
+        queue.async { [weak self] in
+            self?.complete = true
+            self?.finish()
+        }
+    }
+    
+}
+
+class ArrayTests: XCTestCase {
+    
+    var operations: [Operation]!
+    var queue: OperationQueue!
+    var promise: Promise<Void>!
+    
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        operations = nil
+        queue = nil
+        promise = nil
+    }
+    
+    func testArrayOfOperationsCanBeContinuedWithPromise() {
+        
+        let expection = expectation(description: "Await outcome of operations")
+        
+        let operation1 = DelayedOperation()
+        let operation2 = DelayedOperation()
+        let operation3 = DelayedOperation()
+        let operation4 = DelayedOperation()
+        let operation5 = DelayedOperation()
+        
+        operations = [operation1, operation2, operation3, operation4, operation5]
+        
+        promise = operations.continuation { () -> Promise<Void> in
+            return Promise { promise in
+                
+                XCTAssertTrue(operation1.complete)
+                XCTAssertTrue(operation2.complete)
+                XCTAssertTrue(operation3.complete)
+                XCTAssertTrue(operation4.complete)
+                XCTAssertTrue(operation5.complete)
+                
+                promise.futureState = .result()
+                
+                expection.fulfill()
+            }
+        }
+        
+        // Start operations
+        queue.addOperations(operations, waitUntilFinished: false)
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testArrayOfOperationsCanBeContinuedWithBlock() {
+        
+        let expection = expectation(description: "Await outcome of operations")
+        
+        let operation1 = DelayedOperation()
+        let operation2 = DelayedOperation()
+        let operation3 = DelayedOperation()
+        let operation4 = DelayedOperation()
+        let operation5 = DelayedOperation()
+        
+        operations = [operation1, operation2, operation3, operation4, operation5]
+        
+        operations.continuation { 
+            
+            XCTAssertTrue(operation1.complete)
+            XCTAssertTrue(operation2.complete)
+            XCTAssertTrue(operation3.complete)
+            XCTAssertTrue(operation4.complete)
+            XCTAssertTrue(operation5.complete)
+            
+            expection.fulfill()
+        }
+        
+        // Start operations
+        queue.addOperations(operations, waitUntilFinished: false)
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+}

--- a/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSPromiseTests.swift
+++ b/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSPromiseTests.swift
@@ -1,5 +1,5 @@
 //
-//  JustPromisesSwift_iOSTests.swift
+//  JustPromisesSwift_iOSPromiseTests.swift
 //  JustPromisesSwift_iOSTests
 //
 //  Created by Keith Moon on 04/12/2016.
@@ -287,7 +287,7 @@ class PromiseTests: XCTestCase {
         }
     }
     
-    func testPromiseWillFailAfterGivenNumberOFReties() {
+    func testPromiseWillFailAfterGivenNumberOfRetries() {
         
         let asyncExpectation1 = expectation(description: "Await execution")
         

--- a/JustPromisesSwift/Targets/macOS/Tests/JustPromisesSwift_macOSArrayTests.swift
+++ b/JustPromisesSwift/Targets/macOS/Tests/JustPromisesSwift_macOSArrayTests.swift
@@ -1,0 +1,113 @@
+//
+//  JustPromisesSwift_macOSArrayTests.swift
+//  JustPromisesSwift_macOSTests
+//
+//  Created by Keith Moon [Contractor] on 2/10/17.
+//  Copyright © 2017 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import JustPromisesSwift_macOS
+import Dispatch
+import Foundation
+
+class DelayedOperation: AsyncOperation {
+    
+    var complete: Bool = false
+    let queue = DispatchQueue(label: UUID().uuidString)
+    
+    override func execute() {
+        
+        queue.async { [weak self] in
+            self?.complete = true
+            self?.finish()
+        }
+    }
+    
+}
+
+class ArrayTests: XCTestCase {
+    
+    var operations: [Operation]!
+    var queue: OperationQueue!
+    var promise: Promise<Void>!
+    
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        operations = nil
+        queue = nil
+        promise = nil
+    }
+    
+    func testArrayOfOperationsCanBeContinuedWithPromise() {
+        
+        let expection = expectation(description: "Await outcome of operations")
+        
+        let operation1 = DelayedOperation()
+        let operation2 = DelayedOperation()
+        let operation3 = DelayedOperation()
+        let operation4 = DelayedOperation()
+        let operation5 = DelayedOperation()
+        
+        operations = [operation1, operation2, operation3, operation4, operation5]
+        
+        promise = operations.continuation { () -> Promise<Void> in
+            return Promise { promise in
+                
+                XCTAssertTrue(operation1.complete)
+                XCTAssertTrue(operation2.complete)
+                XCTAssertTrue(operation3.complete)
+                XCTAssertTrue(operation4.complete)
+                XCTAssertTrue(operation5.complete)
+                
+                promise.futureState = .result()
+                
+                expection.fulfill()
+            }
+        }
+        
+        // Start operations
+        queue.addOperations(operations, waitUntilFinished: false)
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testArrayOfOperationsCanBeContinuedWithBlock() {
+        
+        let expection = expectation(description: "Await outcome of operations")
+        
+        let operation1 = DelayedOperation()
+        let operation2 = DelayedOperation()
+        let operation3 = DelayedOperation()
+        let operation4 = DelayedOperation()
+        let operation5 = DelayedOperation()
+        
+        operations = [operation1, operation2, operation3, operation4, operation5]
+        
+        operations.continuation { 
+            
+            XCTAssertTrue(operation1.complete)
+            XCTAssertTrue(operation2.complete)
+            XCTAssertTrue(operation3.complete)
+            XCTAssertTrue(operation4.complete)
+            XCTAssertTrue(operation5.complete)
+            
+            expection.fulfill()
+        }
+        
+        // Start operations
+        queue.addOperations(operations, waitUntilFinished: false)
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+}

--- a/JustPromisesSwift/Targets/macOS/Tests/JustPromisesSwift_macOSPromiseTests.swift
+++ b/JustPromisesSwift/Targets/macOS/Tests/JustPromisesSwift_macOSPromiseTests.swift
@@ -1,6 +1,6 @@
 //
-//  JustPromisesSwift_tvOSTests.swift
-//  JustPromisesSwift_tvOSTests
+//  JustPromisesSwift_macOSPromiseTests.swift
+//  JustPromisesSwift_macOSTests
 //
 //  Created by Keith Moon on 04/12/2016.
 //  Copyright © 2016 JUST EAT. All rights reserved.
@@ -8,7 +8,7 @@
 
 import XCTest
 import Foundation
-import JustPromisesSwift_tvOS
+import JustPromisesSwift_macOS
 
 enum TestError: Error {
     case somethingWentWrong

--- a/JustPromisesSwift/Targets/tvOS/Tests/JustPromisesSwift_tvOSArrayTests.swift
+++ b/JustPromisesSwift/Targets/tvOS/Tests/JustPromisesSwift_tvOSArrayTests.swift
@@ -1,0 +1,113 @@
+//
+//  JustPromisesSwift_tvOSArrayTests.swift
+//  JustPromisesSwift_tvOSTests
+//
+//  Created by Keith Moon on 04/12/2016.
+//  Copyright © 2016 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import Foundation
+import JustPromisesSwift_tvOS
+import Dispatch
+
+class DelayedOperation: AsyncOperation {
+    
+    var complete: Bool = false
+    let queue = DispatchQueue(label: UUID().uuidString)
+    
+    override func execute() {
+        
+        queue.async { [weak self] in
+            self?.complete = true
+            self?.finish()
+        }
+    }
+    
+}
+
+class ArrayTests: XCTestCase {
+    
+    var operations: [Operation]!
+    var queue: OperationQueue!
+    var promise: Promise<Void>!
+    
+    override func setUp() {
+        super.setUp()
+        queue = OperationQueue()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        operations = nil
+        queue = nil
+        promise = nil
+    }
+    
+    func testArrayOfOperationsCanBeContinuedWithPromise() {
+        
+        let expection = expectation(description: "Await outcome of operations")
+        
+        let operation1 = DelayedOperation()
+        let operation2 = DelayedOperation()
+        let operation3 = DelayedOperation()
+        let operation4 = DelayedOperation()
+        let operation5 = DelayedOperation()
+        
+        operations = [operation1, operation2, operation3, operation4, operation5]
+        
+        promise = operations.continuation { () -> Promise<Void> in
+            return Promise { promise in
+                
+                XCTAssertTrue(operation1.complete)
+                XCTAssertTrue(operation2.complete)
+                XCTAssertTrue(operation3.complete)
+                XCTAssertTrue(operation4.complete)
+                XCTAssertTrue(operation5.complete)
+                
+                promise.futureState = .result()
+                
+                expection.fulfill()
+            }
+        }
+        
+        // Start operations
+        queue.addOperations(operations, waitUntilFinished: false)
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testArrayOfOperationsCanBeContinuedWithBlock() {
+        
+        let expection = expectation(description: "Await outcome of operations")
+        
+        let operation1 = DelayedOperation()
+        let operation2 = DelayedOperation()
+        let operation3 = DelayedOperation()
+        let operation4 = DelayedOperation()
+        let operation5 = DelayedOperation()
+        
+        operations = [operation1, operation2, operation3, operation4, operation5]
+        
+        operations.continuation {
+            
+            XCTAssertTrue(operation1.complete)
+            XCTAssertTrue(operation2.complete)
+            XCTAssertTrue(operation3.complete)
+            XCTAssertTrue(operation4.complete)
+            XCTAssertTrue(operation5.complete)
+            
+            expection.fulfill()
+        }
+        
+        // Start operations
+        queue.addOperations(operations, waitUntilFinished: false)
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+}

--- a/JustPromisesSwift/Targets/tvOS/Tests/JustPromisesSwift_tvOSPromiseTests.swift
+++ b/JustPromisesSwift/Targets/tvOS/Tests/JustPromisesSwift_tvOSPromiseTests.swift
@@ -1,6 +1,6 @@
 //
-//  JustPromisesSwift_macOSTests.swift
-//  JustPromisesSwift_macOSTests
+//  JustPromisesSwift_tvOSPromiseTests.swift
+//  JustPromisesSwift_tvOSTests
 //
 //  Created by Keith Moon on 04/12/2016.
 //  Copyright © 2016 JUST EAT. All rights reserved.
@@ -8,7 +8,7 @@
 
 import XCTest
 import Foundation
-import JustPromisesSwift_macOS
+import JustPromisesSwift_tvOS
 
 enum TestError: Error {
     case somethingWentWrong


### PR DESCRIPTION
There is a typo in the implementation of continuing an array of operations. This PR fixes this and add Unit Tests for that functionality.