### PR TITLE
Key Value Observing with Promises

### DIFF
--- a/JustPromises.podspec
+++ b/JustPromises.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "JustPromises"
-  s.version      = "3.0.1"
-  s.summary      = "A lightweight and thread-safe implementation of Promises & Futures in Objective-C for iOS and OS X."
+  s.version      = "3.1.0"
+  s.summary      = "A lightweight and thread-safe implementation of Promises & Futures in both Objective-C and Swift 3 for iOS, macOS, watchOS and tvOS."
 
   s.description  = <<-DESC
                    A longer description of JustPromises in Markdown format.
@@ -79,7 +79,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/justeat/JustPromises.git", :tag => "3.0.1" }
+  s.source       = { :git => "https://github.com/justeat/JustPromises.git", :tag => "3.1.0" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/JustPromises.xcodeproj/project.pbxproj
+++ b/JustPromises.xcodeproj/project.pbxproj
@@ -237,9 +237,9 @@
 		2F5829601DF4A7DE0033C3D4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				B142DDBE1E6435D800946479 /* KVOPromise.swift */,
 				2F5829611DF4A7DE0033C3D4 /* AsyncOperation.swift */,
 				2F5829621DF4A7DE0033C3D4 /* Promise.swift */,
+				B142DDBE1E6435D800946479 /* KVOPromise.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";

--- a/JustPromises.xcodeproj/project.pbxproj
+++ b/JustPromises.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		4FCF53A01B47F5480025D30D /* JEFuture+JEDotNotation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FCF539E1B47F5480025D30D /* JEFuture+JEDotNotation.h */; };
 		4FCF53A11B47F5480025D30D /* JEFuture+JEDotNotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF539F1B47F5480025D30D /* JEFuture+JEDotNotation.m */; };
 		4FCF53A31B47F5820025D30D /* JEFuture_DotNotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF53A21B47F5820025D30D /* JEFuture_DotNotationTests.m */; };
+		B142DDBF1E6435D800946479 /* KVOPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDBE1E6435D800946479 /* KVOPromise.swift */; };
+		B142DDC11E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */; };
 		B1FA8F9D1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */; };
 		B1FA8F9F1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */; };
 		B1FA8FA11E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */; };
@@ -129,6 +131,8 @@
 		4FCF53A21B47F5820025D30D /* JEFuture_DotNotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JEFuture_DotNotationTests.m; sourceTree = "<group>"; };
 		B13CA05B1DD0D81900E4F710 /* README_ObjC.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_ObjC.md; sourceTree = "<group>"; };
 		B13CA05C1DD0D82C00E4F710 /* README_Swift.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_Swift.md; sourceTree = "<group>"; };
+		B142DDBE1E6435D800946479 /* KVOPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KVOPromise.swift; sourceTree = "<group>"; };
+		B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSKVOTests.swift; sourceTree = "<group>"; };
 		B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSArrayTests.swift; sourceTree = "<group>"; };
 		B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_macOSArrayTests.swift; sourceTree = "<group>"; };
 		B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_tvOSArrayTests.swift; sourceTree = "<group>"; };
@@ -226,6 +230,7 @@
 		2F5829601DF4A7DE0033C3D4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				B142DDBE1E6435D800946479 /* KVOPromise.swift */,
 				2F5829611DF4A7DE0033C3D4 /* AsyncOperation.swift */,
 				2F5829621DF4A7DE0033C3D4 /* Promise.swift */,
 			);
@@ -264,6 +269,7 @@
 		2F5829681DF4A7DE0033C3D4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */,
 				2F5829691DF4A7DE0033C3D4 /* Info.plist */,
 				2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift */,
 				B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */,
@@ -697,6 +703,7 @@
 					};
 					4FBCFFDD1B46DC9F007BD426 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0820;
 					};
 					4FBCFFE61B46DC9F007BD426 = {
 						CreatedOnToolsVersion = 7.0;
@@ -885,7 +892,9 @@
 			files = (
 				4FBC00051B46DCE2007BD426 /* JEFuture.m in Sources */,
 				4FBC00071B46DCE2007BD426 /* JEProgress.m in Sources */,
+				B142DDBF1E6435D800946479 /* KVOPromise.swift in Sources */,
 				4FCF53A11B47F5480025D30D /* JEFuture+JEDotNotation.m in Sources */,
+				B142DDC11E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1339,6 +1348,7 @@
 		4FBCFFF61B46DC9F007BD426 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1354,6 +1364,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustPromises;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1363,6 +1375,7 @@
 		4FBCFFF71B46DC9F007BD426 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1378,6 +1391,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustPromises;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1387,6 +1401,7 @@
 		4FBCFFFA1B46DC9F007BD426 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_TESTABILITY = YES;
@@ -1401,6 +1416,7 @@
 		4FBCFFFB1B46DC9F007BD426 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/JustPromises.xcodeproj/project.pbxproj
+++ b/JustPromises.xcodeproj/project.pbxproj
@@ -30,19 +30,24 @@
 		4F74B0ED1B47CF6500595442 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F74B0E81B47CF6500595442 /* main.m */; };
 		4F74B0F01B47CFD100595442 /* JEDemoExamples.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F74B0EF1B47CFD100595442 /* JEDemoExamples.m */; };
 		4F74B0F11B47D03C00595442 /* JustPromises.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FBCFFDE1B46DC9F007BD426 /* JustPromises.framework */; };
-		4FBC00041B46DCE2007BD426 /* JEFuture.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBCFFFE1B46DCE2007BD426 /* JEFuture.h */; };
+		4FBC00041B46DCE2007BD426 /* JEFuture.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBCFFFE1B46DCE2007BD426 /* JEFuture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FBC00051B46DCE2007BD426 /* JEFuture.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FBCFFFF1B46DCE2007BD426 /* JEFuture.m */; };
-		4FBC00061B46DCE2007BD426 /* JEProgress.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBC00001B46DCE2007BD426 /* JEProgress.h */; };
+		4FBC00061B46DCE2007BD426 /* JEProgress.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBC00001B46DCE2007BD426 /* JEProgress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FBC00071B46DCE2007BD426 /* JEProgress.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FBC00011B46DCE2007BD426 /* JEProgress.m */; };
-		4FBC00081B46DCE2007BD426 /* JustPromises.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBC00021B46DCE2007BD426 /* JustPromises.h */; };
+		4FBC00081B46DCE2007BD426 /* JustPromises.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBC00021B46DCE2007BD426 /* JustPromises.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FBC000E1B46DD1B007BD426 /* JEFutureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FBC000B1B46DD1B007BD426 /* JEFutureTests.m */; };
 		4FBC000F1B46DD1B007BD426 /* JEProgressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FBC000C1B46DD1B007BD426 /* JEProgressTests.m */; };
 		4FBCFFE81B46DC9F007BD426 /* JustPromises.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FBCFFDE1B46DC9F007BD426 /* JustPromises.framework */; };
-		4FCF53A01B47F5480025D30D /* JEFuture+JEDotNotation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FCF539E1B47F5480025D30D /* JEFuture+JEDotNotation.h */; };
+		4FCF53A01B47F5480025D30D /* JEFuture+JEDotNotation.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FCF539E1B47F5480025D30D /* JEFuture+JEDotNotation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FCF53A11B47F5480025D30D /* JEFuture+JEDotNotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF539F1B47F5480025D30D /* JEFuture+JEDotNotation.m */; };
 		4FCF53A31B47F5820025D30D /* JEFuture_DotNotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF53A21B47F5820025D30D /* JEFuture_DotNotationTests.m */; };
-		B142DDBF1E6435D800946479 /* KVOPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDBE1E6435D800946479 /* KVOPromise.swift */; };
-		B142DDC11E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */; };
+		B142DDC71E64389A00946479 /* JustPromisesSwift_iOSKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */; };
+		B142DDC81E6438A200946479 /* JustPromisesSwift_macOSKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDC21E6436CC00946479 /* JustPromisesSwift_macOSKVOTests.swift */; };
+		B142DDC91E6438AB00946479 /* JustPromisesSwift_tvOSKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDC41E6436FA00946479 /* JustPromisesSwift_tvOSKVOTests.swift */; };
+		B142DDCA1E6438CC00946479 /* KVOPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDBE1E6435D800946479 /* KVOPromise.swift */; };
+		B142DDCB1E6438CE00946479 /* KVOPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDBE1E6435D800946479 /* KVOPromise.swift */; };
+		B142DDCC1E6438CF00946479 /* KVOPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDBE1E6435D800946479 /* KVOPromise.swift */; };
+		B142DDCD1E6438D000946479 /* KVOPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B142DDBE1E6435D800946479 /* KVOPromise.swift */; };
 		B1FA8F9D1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */; };
 		B1FA8F9F1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */; };
 		B1FA8FA11E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */; };
@@ -133,6 +138,8 @@
 		B13CA05C1DD0D82C00E4F710 /* README_Swift.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_Swift.md; sourceTree = "<group>"; };
 		B142DDBE1E6435D800946479 /* KVOPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KVOPromise.swift; sourceTree = "<group>"; };
 		B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSKVOTests.swift; sourceTree = "<group>"; };
+		B142DDC21E6436CC00946479 /* JustPromisesSwift_macOSKVOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_macOSKVOTests.swift; sourceTree = "<group>"; };
+		B142DDC41E6436FA00946479 /* JustPromisesSwift_tvOSKVOTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_tvOSKVOTests.swift; sourceTree = "<group>"; };
 		B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_iOSArrayTests.swift; sourceTree = "<group>"; };
 		B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_macOSArrayTests.swift; sourceTree = "<group>"; };
 		B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustPromisesSwift_tvOSArrayTests.swift; sourceTree = "<group>"; };
@@ -269,10 +276,10 @@
 		2F5829681DF4A7DE0033C3D4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */,
 				2F5829691DF4A7DE0033C3D4 /* Info.plist */,
 				2F58296A1DF4A7DE0033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift */,
 				B1FA8F9C1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift */,
+				B142DDC01E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -301,6 +308,7 @@
 				2F5829701DF4A7DE0033C3D4 /* Info.plist */,
 				2F5829711DF4A7DE0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift */,
 				B1FA8F9E1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift */,
+				B142DDC21E6436CC00946479 /* JustPromisesSwift_macOSKVOTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -329,6 +337,7 @@
 				2F5829771DF4A7DE0033C3D4 /* Info.plist */,
 				2F5829781DF4A7DE0033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift */,
 				B1FA8FA01E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift */,
+				B142DDC41E6436FA00946479 /* JustPromisesSwift_tvOSKVOTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -819,6 +828,7 @@
 			files = (
 				2F5829851DF4A8280033C3D4 /* AsyncOperation.swift in Sources */,
 				2F5829861DF4A8280033C3D4 /* Promise.swift in Sources */,
+				B142DDCA1E6438CC00946479 /* KVOPromise.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -828,6 +838,7 @@
 			files = (
 				2F58297F1DF4A7F80033C3D4 /* JustPromisesSwift_iOSPromiseTests.swift in Sources */,
 				B1FA8F9D1E4DD5FF00D217DB /* JustPromisesSwift_iOSArrayTests.swift in Sources */,
+				B142DDC71E64389A00946479 /* JustPromisesSwift_iOSKVOTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -837,6 +848,7 @@
 			files = (
 				2F5829871DF4A8290033C3D4 /* AsyncOperation.swift in Sources */,
 				2F5829881DF4A8290033C3D4 /* Promise.swift in Sources */,
+				B142DDCB1E6438CE00946479 /* KVOPromise.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -846,6 +858,7 @@
 			files = (
 				2F5829891DF4A82B0033C3D4 /* AsyncOperation.swift in Sources */,
 				2F58298A1DF4A82B0033C3D4 /* Promise.swift in Sources */,
+				B142DDCC1E6438CF00946479 /* KVOPromise.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -853,6 +866,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B142DDC91E6438AB00946479 /* JustPromisesSwift_tvOSKVOTests.swift in Sources */,
 				2F5829831DF4A8150033C3D4 /* JustPromisesSwift_tvOSPromiseTests.swift in Sources */,
 				B1FA8FA11E4DE29800D217DB /* JustPromisesSwift_tvOSArrayTests.swift in Sources */,
 			);
@@ -864,6 +878,7 @@
 			files = (
 				2F58298B1DF4A82C0033C3D4 /* AsyncOperation.swift in Sources */,
 				2F58298C1DF4A82C0033C3D4 /* Promise.swift in Sources */,
+				B142DDCD1E6438D000946479 /* KVOPromise.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -871,6 +886,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B142DDC81E6438A200946479 /* JustPromisesSwift_macOSKVOTests.swift in Sources */,
 				2F5829811DF4A80A0033C3D4 /* JustPromisesSwift_macOSPromiseTests.swift in Sources */,
 				B1FA8F9F1E4DE17D00D217DB /* JustPromisesSwift_macOSArrayTests.swift in Sources */,
 			);
@@ -892,9 +908,7 @@
 			files = (
 				4FBC00051B46DCE2007BD426 /* JEFuture.m in Sources */,
 				4FBC00071B46DCE2007BD426 /* JEProgress.m in Sources */,
-				B142DDBF1E6435D800946479 /* KVOPromise.swift in Sources */,
 				4FCF53A11B47F5480025D30D /* JEFuture+JEDotNotation.m in Sources */,
-				B142DDC11E6435DF00946479 /* JustPromisesSwift_iOSKVOTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1401,7 +1415,6 @@
 		4FBCFFFA1B46DC9F007BD426 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_TESTABILITY = YES;
@@ -1416,7 +1429,6 @@
 		4FBCFFFB1B46DC9F007BD426 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/JustPromisesSwift/Sources/KVOPromise.swift
+++ b/JustPromisesSwift/Sources/KVOPromise.swift
@@ -1,0 +1,63 @@
+//
+//  File.swift
+//  JustPromises
+//
+//  Created by Keith Moon [Contractor] on 2/24/17.
+//  Copyright © 2017 JUST EAT. All rights reserved.
+//
+
+import Foundation
+
+open class KVOPromise<FutureType, ObservingType: NSObject>: Promise<FutureType> {
+    
+    open weak var objectToObserve: ObservingType?
+    open var keyPath: String
+    open var options: NSKeyValueObservingOptions
+    open var context: UnsafeMutableRawPointer?
+    open var observeBlock: (ObservingType, [NSKeyValueChangeKey : Any], Promise<FutureType>) -> Void
+    
+    public init(objectToObserve object: ObservingType,
+         forKeyPath keyPath: String,
+         options: NSKeyValueObservingOptions,
+         context: UnsafeMutableRawPointer? = nil,
+         observeBlock:@escaping (ObservingType, [NSKeyValueChangeKey : Any], Promise<FutureType>) -> Void) {
+        
+        self.objectToObserve = object
+        self.keyPath = keyPath
+        self.options = options
+        self.context = context
+        self.observeBlock = observeBlock
+        
+        super.init() { promise in
+            object.addObserver(promise, forKeyPath: keyPath, options: options, context: context)
+        }
+    }
+    
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        
+        if let providedContext = self.context, providedContext != context {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            return
+        }
+        
+        guard
+            let providedObject = objectToObserve,
+            let triggeredObject = object as? ObservingType,
+            providedObject == triggeredObject,
+            let triggeredKeyPath = keyPath,
+            self.keyPath == triggeredKeyPath,
+            let changeDictionary = change
+            else {
+                print("Sending to Super: KeyPath: \(keyPath), Object: \(object), Change: \(change), Context: \(context)")
+                super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+                return
+        }
+        
+        observeBlock(triggeredObject, changeDictionary, self)
+    }
+    
+    open override func finish() {
+        objectToObserve?.removeObserver(self, forKeyPath: keyPath, context: context)
+        super.finish()
+    }
+}

--- a/JustPromisesSwift/Sources/KVOPromise.swift
+++ b/JustPromisesSwift/Sources/KVOPromise.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// A promise to fulfill try and fulfill a future value, which respect to a KVO keypath.
 open class KVOPromise<FutureType, ObservingType: NSObject>: Promise<FutureType> {
     
     open weak var objectToObserve: ObservingType?
@@ -16,6 +17,17 @@ open class KVOPromise<FutureType, ObservingType: NSObject>: Promise<FutureType> 
     open var context: UnsafeMutableRawPointer?
     open var observeBlock: (ObservingType, [NSKeyValueChangeKey : Any], Promise<FutureType>) -> Void
     
+    /// Create a promise to perform Key-Value Observing.
+    /// 
+    /// - parameter objectToObserve: The object to observe
+    /// - parameter forKeyPath: The keypath to observe
+    /// - parameter options: The KVO options to use
+    /// - parameter context: Optional context for KVO
+    /// - parameter observeBlock: Block that receives the observed object, the change dictionary and a reference to the promise. 
+    ///                           This fires whenever there is a change to the keypath in line with provided options. 
+    ///                           Block should eventually fulfill the futureState of the Promise.
+    ///
+    /// - returns: A Promise, that has not been put on a queue. Call await() or awaitOnMainQueue() to enqueue
     public init(objectToObserve object: ObservingType,
          forKeyPath keyPath: String,
          options: NSKeyValueObservingOptions,

--- a/JustPromisesSwift/Sources/Promise.swift
+++ b/JustPromisesSwift/Sources/Promise.swift
@@ -108,6 +108,7 @@ extension Promise {
     /// - parameter queue: The queue to await the promise on.
     ///
     /// - returns: The same promise will be returned, allowing chaining.
+    @discardableResult
     public func await(onQueue queue: OperationQueue = sharedPromiseQueue) -> Promise<FutureType> {
         queue.addOperation(self)
         return self
@@ -116,6 +117,7 @@ extension Promise {
     /// The promise will be added to the main queue.
     ///
     /// - returns: The same promise will be returned, allowing chaining.
+    @discardableResult
     public func awaitOnMainQueue() -> Promise<FutureType>  {
         return await(onQueue: .main)
     }
@@ -129,6 +131,7 @@ extension Promise {
     /// - parameter executionBlock: The block to create and return the next Promise
     ///
     /// - returns: The next created Promise, allows chaining.
+    @discardableResult
     public func continuation<NextFutureType>(onQueue queue: OperationQueue = sharedPromiseQueue, withBlock executionBlock: (Promise<FutureType>) -> Promise<NextFutureType>) -> Promise<NextFutureType> {
         
         let nextPromise = executionBlock(self)
@@ -230,6 +233,7 @@ extension Array where Element: Operation {
     /// - parameter executionBlock: The block to create and return the next Promise
     ///
     /// - returns: The next created Promise, allows chaining
+    @discardableResult
     public func continuation<NextFutureType>(onQueue queue: OperationQueue = sharedPromiseQueue, withBlock executionBlock: () -> Promise<NextFutureType>) -> Promise<NextFutureType> {
         
         let nextPromise = executionBlock()

--- a/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSKVOTests.swift
+++ b/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSKVOTests.swift
@@ -1,0 +1,72 @@
+//
+//  JustPromisesSwift_iOSKVOTests.swift
+//  JustPromises
+//
+//  Created by Keith Moon [Contractor] on 2/27/17.
+//  Copyright © 2017 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import Dispatch
+import JustPromisesSwift_iOS
+
+class TrivialOperation: AsyncOperation {
+    
+    override func execute() {
+        DispatchQueue.main.async { [weak self] in
+            self?.finish()
+        }
+    }
+}
+
+class JustPromisesSwift_iOSKVOTests: XCTestCase {
+    
+    var promiseQueue: OperationQueue!
+    var operationQueue: OperationQueue!
+    
+    override func setUp() {
+        super.setUp()
+        promiseQueue = OperationQueue()
+        operationQueue = OperationQueue()
+    }
+    
+    override func tearDown() {
+        promiseQueue = nil
+        operationQueue = nil
+        super.tearDown()
+    }
+    
+    func testKVOPromiseCanObserveQueueOperationCount() {
+        
+        let asyncExpectation = expectation(description: "Queue empty")
+        
+        operationQueue.isSuspended = true
+        
+        let op1 = TrivialOperation()
+        let op2 = TrivialOperation()
+        let op3 = TrivialOperation()
+        let op4 = TrivialOperation()
+        let op5 = TrivialOperation()
+        
+        operationQueue.addOperations([op1, op2, op3, op4, op5], waitUntilFinished: false)
+        
+        XCTAssertEqual(operationQueue.operationCount, 5)
+        
+        let kvoPromise = KVOPromise<Void, OperationQueue>(objectToObserve: operationQueue, forKeyPath: "operationCount", options: [.new]) { (object, changeDictionary, promise) in
+            
+            if object.operationCount == 0 {
+                promise.futureState = .result()
+                asyncExpectation.fulfill()
+            }
+        }
+        
+        kvoPromise.await(onQueue: promiseQueue)
+        
+        // Start queue
+        operationQueue.isSuspended = false
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSKVOTests.swift
+++ b/JustPromisesSwift/Targets/iOS/Tests/JustPromisesSwift_iOSKVOTests.swift
@@ -38,7 +38,11 @@ class JustPromisesSwift_iOSKVOTests: XCTestCase {
     
     func testKVOPromiseCanObserveQueueOperationCount() {
         
-        let asyncExpectation = expectation(description: "Queue empty")
+        let asyncExpectation0 = expectation(description: "Queue empty")
+        let asyncExpectation1 = expectation(description: "Queue empty")
+        let asyncExpectation2 = expectation(description: "Queue empty")
+        let asyncExpectation3 = expectation(description: "Queue empty")
+        let asyncExpectation4 = expectation(description: "Queue empty")
         
         operationQueue.isSuspended = true
         
@@ -54,9 +58,25 @@ class JustPromisesSwift_iOSKVOTests: XCTestCase {
         
         let kvoPromise = KVOPromise<Void, OperationQueue>(objectToObserve: operationQueue, forKeyPath: "operationCount", options: [.new]) { (object, changeDictionary, promise) in
             
-            if object.operationCount == 0 {
+            switch object.operationCount {
+                
+            case 4:
+                asyncExpectation4.fulfill()
+                
+            case 3:
+                asyncExpectation3.fulfill()
+                
+            case 2:
+                asyncExpectation2.fulfill()
+                
+            case 1:
+                asyncExpectation1.fulfill()
+                
+            case 0:
                 promise.futureState = .result()
-                asyncExpectation.fulfill()
+                asyncExpectation0.fulfill()
+                
+            default: break
             }
         }
         

--- a/JustPromisesSwift/Targets/macOS/Tests/JustPromisesSwift_macOSKVOTests.swift
+++ b/JustPromisesSwift/Targets/macOS/Tests/JustPromisesSwift_macOSKVOTests.swift
@@ -1,0 +1,72 @@
+//
+//  JustPromisesSwift_iOSKVOTests.swift
+//  JustPromises
+//
+//  Created by Keith Moon [Contractor] on 2/27/17.
+//  Copyright © 2017 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import Dispatch
+import JustPromisesSwift_macOS
+
+class TrivialOperation: AsyncOperation {
+    
+    override func execute() {
+        DispatchQueue.main.async { [weak self] in
+            self?.finish()
+        }
+    }
+}
+
+class JustPromisesSwift_macOSKVOTests: XCTestCase {
+    
+    var promiseQueue: OperationQueue!
+    var operationQueue: OperationQueue!
+    
+    override func setUp() {
+        super.setUp()
+        promiseQueue = OperationQueue()
+        operationQueue = OperationQueue()
+    }
+    
+    override func tearDown() {
+        promiseQueue = nil
+        operationQueue = nil
+        super.tearDown()
+    }
+    
+    func testKVOPromiseCanObserveQueueOperationCount() {
+        
+        let asyncExpectation = expectation(description: "Queue empty")
+        
+        operationQueue.isSuspended = true
+        
+        let op1 = TrivialOperation()
+        let op2 = TrivialOperation()
+        let op3 = TrivialOperation()
+        let op4 = TrivialOperation()
+        let op5 = TrivialOperation()
+        
+        operationQueue.addOperations([op1, op2, op3, op4, op5], waitUntilFinished: false)
+        
+        XCTAssertEqual(operationQueue.operationCount, 5)
+        
+        let kvoPromise = KVOPromise<Void, OperationQueue>(objectToObserve: operationQueue, forKeyPath: "operationCount", options: [.new]) { (object, changeDictionary, promise) in
+            
+            if object.operationCount == 0 {
+                promise.futureState = .result()
+                asyncExpectation.fulfill()
+            }
+        }
+        
+        kvoPromise.await(onQueue: promiseQueue)
+        
+        // Start queue
+        operationQueue.isSuspended = false
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/JustPromisesSwift/Targets/tvOS/Tests/JustPromisesSwift_tvOSKVOTests.swift
+++ b/JustPromisesSwift/Targets/tvOS/Tests/JustPromisesSwift_tvOSKVOTests.swift
@@ -1,0 +1,72 @@
+//
+//  JustPromisesSwift_iOSKVOTests.swift
+//  JustPromises
+//
+//  Created by Keith Moon [Contractor] on 2/27/17.
+//  Copyright © 2017 JUST EAT. All rights reserved.
+//
+
+import XCTest
+import Dispatch
+import JustPromisesSwift_tvOS
+
+class TrivialOperation: AsyncOperation {
+    
+    override func execute() {
+        DispatchQueue.main.async { [weak self] in
+            self?.finish()
+        }
+    }
+}
+
+class JustPromisesSwift_tvOSKVOTests: XCTestCase {
+    
+    var promiseQueue: OperationQueue!
+    var operationQueue: OperationQueue!
+    
+    override func setUp() {
+        super.setUp()
+        promiseQueue = OperationQueue()
+        operationQueue = OperationQueue()
+    }
+    
+    override func tearDown() {
+        promiseQueue = nil
+        operationQueue = nil
+        super.tearDown()
+    }
+    
+    func testKVOPromiseCanObserveQueueOperationCount() {
+        
+        let asyncExpectation = expectation(description: "Queue empty")
+        
+        operationQueue.isSuspended = true
+        
+        let op1 = TrivialOperation()
+        let op2 = TrivialOperation()
+        let op3 = TrivialOperation()
+        let op4 = TrivialOperation()
+        let op5 = TrivialOperation()
+        
+        operationQueue.addOperations([op1, op2, op3, op4, op5], waitUntilFinished: false)
+        
+        XCTAssertEqual(operationQueue.operationCount, 5)
+        
+        let kvoPromise = KVOPromise<Void, OperationQueue>(objectToObserve: operationQueue, forKeyPath: "operationCount", options: [.new]) { (object, changeDictionary, promise) in
+            
+            if object.operationCount == 0 {
+                promise.futureState = .result()
+                asyncExpectation.fulfill()
+            }
+        }
+        
+        kvoPromise.await(onQueue: promiseQueue)
+        
+        // Start queue
+        operationQueue.isSuspended = false
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](JustPromises_logo.jpg)
 
-A lightweight and thread-safe implementation of Promises & Futures in both Objective-C and Swift 3 for iOS, macOS, watchOS and tvOS with 100% code coverage.
+A lightweight and thread-safe implementation of Promises & Futures in both Objective-C and Swift 3 for iOS, macOS, watchOS and tvOS.
 
 #Overview
 


### PR DESCRIPTION
Adds a ```Promise``` subclass, ```KVOPromise```. 

```KVOPromise``` will observe a given object for a give keypath and fire the ```observeBlock``` whenever the value at that keypath changes. The ```observeBlock``` is responsible for setting the ```futureState``` when the objective has been achieved, which will finish the Promise.